### PR TITLE
Removed asynchronous race condition

### DIFF
--- a/Pikko/Sources/Pikko/Classes/UI/BrightnessSaturationView.swift
+++ b/Pikko/Sources/Pikko/Classes/UI/BrightnessSaturationView.swift
@@ -268,14 +268,9 @@ internal class BrightnessSaturationView: UIView {
 
 extension BrightnessSaturationView: HueDelegate {
     internal func didUpdateHue(hue: CGFloat) {
-        DispatchQueue.main.async {
-            self.hue = hue
-            self.updateSelectorColor(point: self.selector.center)
-        }
-        
-        DispatchQueue.main.async {
-            self.saturationLayer?.colors = self.generateSaturationInterpolationArray(hue: hue)
-        }
+        self.hue = hue
+        self.updateSelectorColor(point: self.selector.center)
+        self.saturationLayer?.colors = self.generateSaturationInterpolationArray(hue: hue)
     }
 }
 


### PR DESCRIPTION
These `DispatchQueue.main.async` where creating a race condition where even when creating the color picker with a given color it could reset its hue.