### PR TITLE
fix: weak delegates to prevent leaks

### DIFF
--- a/Pikko/Sources/Pikko/Classes/Delegate/HueDelegate.swift
+++ b/Pikko/Sources/Pikko/Classes/Delegate/HueDelegate.swift
@@ -12,6 +12,6 @@ import UIKit
 
 
 /// Delegate used for writing back hue updates from the HueView.
-internal protocol HueDelegate {
+internal protocol HueDelegate: AnyObject {
     func didUpdateHue(hue: CGFloat)
 }

--- a/Pikko/Sources/Pikko/Classes/Delegate/PikkoDelegate.swift
+++ b/Pikko/Sources/Pikko/Classes/Delegate/PikkoDelegate.swift
@@ -10,7 +10,7 @@ import Foundation
 import UIKit
 
 /// Delegate which propagates color changes of the colorpicker to its delegate.
-public protocol PikkoDelegate {
+public protocol PikkoDelegate: AnyObject {
     func writeBackColor(color: UIColor)
 }
 

--- a/Pikko/Sources/Pikko/Classes/UI/BrightnessSaturationView.swift
+++ b/Pikko/Sources/Pikko/Classes/UI/BrightnessSaturationView.swift
@@ -40,7 +40,7 @@ internal class BrightnessSaturationView: UIView {
     // MARK: - Public attributes.
     
     /// Delegate method for writing back changes in the color selection.
-    internal var delegate: PikkoDelegate?
+    internal weak var delegate: PikkoDelegate?
     
     // MARK: - Initializer.
     

--- a/Pikko/Sources/Pikko/Classes/UI/HueView.swift
+++ b/Pikko/Sources/Pikko/Classes/UI/HueView.swift
@@ -42,7 +42,7 @@ internal class HueView: UIView {
     // MARK: Public attributes.
     
     /// Delegate that writes back changes of the hue value.
-    internal var delegate: HueDelegate?
+    internal weak var delegate: HueDelegate?
     
     // MARK: - Initializer.
     

--- a/Pikko/Sources/Pikko/Classes/UI/Pikko.swift
+++ b/Pikko/Sources/Pikko/Classes/UI/Pikko.swift
@@ -22,7 +22,7 @@ public class Pikko: UIView {
 
     
     /// The PikkoDelegate that is called whenever the color is updated.
-    public var delegate: PikkoDelegate?
+    public weak var delegate: PikkoDelegate?
     
     // MARK: - Initializer.
 


### PR DESCRIPTION
Strong delegate references are creating reference cycles. This isn't noticeable with the Example app because there's a single view controller. But if you'd use Pikko in a VC that was presented as modal or pushed into a navigation stack, the memory debugger would show that instances of the VC, Pikko, HueView and BrightnessSaturationView never go away due to the cycle created by the delegates.